### PR TITLE
fix: make verify workable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 notifications:
   slack: eternitywall:etqKsfod1e0lcsOFby1npMh6g

--- a/src/main/java/com/eternitywall/http/Request.java
+++ b/src/main/java/com/eternitywall/http/Request.java
@@ -55,7 +55,8 @@ public class Request implements Callable<Response> {
             HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
             httpURLConnection.setReadTimeout(10000);
             httpURLConnection.setConnectTimeout(10000);
-            httpURLConnection.setRequestProperty("User-Agent", "java");
+            httpURLConnection.setRequestProperty("User-Agent", "OpenTimestamps/1.17");
+            httpURLConnection.setRequestProperty("Accept", "application/json");
 
             if (headers != null) {
                 for (Map.Entry<String, String> entry : headers.entrySet()) {

--- a/src/main/java/com/eternitywall/ots/MultiInsight.java
+++ b/src/main/java/com/eternitywall/ots/MultiInsight.java
@@ -35,7 +35,7 @@ public class MultiInsight {
         if (chain.equals("bitcoin")) {
             //insightUrls.add("https://search.bitaccess.co/insight-api");
             //insightUrls.add("https://www.localbitcoinschain.com/api");
-            //insightUrls.add("https://insight.bitpay.com/api");
+            insightUrls.add("https://insight.bitpay.com/api");
             //insightUrls.add("https://finney.calendar.eternitywall.com/insight-api");
             insightUrls.add("https://btc-bitcore1.trezor.io/api");
             //insightUrls.add("https://btc-bitcore4.trezor.io/api");
@@ -79,7 +79,7 @@ public class MultiInsight {
                 JSONObject jsonObject = take.getJson();
 
                 try {
-                    String merkleroot = jsonObject.getString("merkleroot");
+                    String merkleroot = jsonObject.has("merkleroot") ? jsonObject.getString("merkleroot") : jsonObject.getString("merkleRoot");
                     String time = String.valueOf(jsonObject.getInt("time"));
                     BlockHeader blockHeader = new BlockHeader();
                     blockHeader.setMerkleroot(merkleroot);
@@ -93,7 +93,7 @@ public class MultiInsight {
 
                     results.add(blockHeader);
                 } catch (JSONException e) {
-                    log.warning("Cannot parse merkleroot from body: " + jsonObject);
+                    log.warning("Cannot parse merkleroot from body: " + jsonObject + ": " + e.getMessage());
                 }
             }
         }

--- a/src/main/java/com/eternitywall/ots/OtsCli.java
+++ b/src/main/java/com/eternitywall/ots/OtsCli.java
@@ -355,8 +355,7 @@ public class OtsCli {
                     System.out.println("Success! " + Utils.toUpperFirstLetter(chain) + " " + entry.getValue().toString());
                 }
             } catch (Exception e) {
-                System.out.println(e.getMessage());
-
+                e.printStackTrace();
                 return;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Blockexplorer is constantly returning 503 Service Unavailable so needed to bring Bitpay block explorer.
Some explorers are returning `merkleRoot` instead of `merkleroot`, so went ahead and fixed it.
Also fixed some headers so we can provide something more meaningful to the server rather than just "java", and enforce that we expecting JSON responses.