### PR TITLE
fix: create two jars (with and without dependencies)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,27 +101,30 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.0.0</version>
-
                 <executions>
                     <execution>
                         <phase>package</phase>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <id>cli</id>
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <configuration>
+                            <finalName>OtsCli</finalName>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.eternitywall.ots.OtsCli</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <finalName>OtsCli</finalName>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.eternitywall.ots.OtsCli</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
The single option causes jar hell with sometimes impossible ways to solve.
For example, I can't have log4j-simple in my project, and can't exclude it either, so had to repackage it.