### PR TITLE
java 9+: jabx dependencies and attach-javadocs cfg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
 
 
     </dependencies>
@@ -153,13 +159,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <use>false</use>
+                            <source>1.8</source>
+                                <links>
+                                    <link>http://docs.oracle.com/javase/7/docs/api/</link>
+                                </links>
+                            <doclint>none</doclint>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
        modified pom.xml to build with java 9+
        - jabx dependencies
        - attach-javadocs plugin configuration

fix #40 