### PR TITLE
SLF4J support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Java 1.7+
 ```
 git clone https://github.com/opentimestamps/java-opentimestamps
 cd java-opentimestamps
-mvn install
+mvn install -P cli
 ```
 
 #### SSL errors

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,16 @@
 
     <profiles>
         <profile>
+            <id>cli</id>
+            <dependencies>
+                <dependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <version>1.2.3</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>release-sign-artifacts</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
     <profiles>
         <profile>
             <id>cli</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>${project.basedir}/src/cli/resources</directory>
+                    </resource>
+                </resources>
+            </build>
             <dependencies>
                 <dependency>
                     <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <version>1.7.29</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.eternitywall</groupId>
     <artifactId>java-opentimestamps</artifactId>
-    <version>1.19</version>
+    <version>1.19.1-SNAPSHOT</version>
 
     <name>java-opentimestamps</name>
     <description>The java implementation of the OpenTimestamps protocol</description>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
+            <artifactId>slf4j-api</artifactId>
             <version>1.7.29</version>
         </dependency>
         <dependency>

--- a/src/cli/resources/logback.xml
+++ b/src/cli/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/main/java/com/eternitywall/http/Request.java
+++ b/src/main/java/com/eternitywall/http/Request.java
@@ -1,6 +1,7 @@
 package com.eternitywall.http;
 
-import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.DataOutputStream;
 import java.io.InputStream;
@@ -11,15 +12,13 @@ import java.net.URLEncoder;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipException;
 
 /**
  * For making an HTTP request.
  */
 public class Request implements Callable<Response> {
-    private static Logger log = Utils.getLogger(Request.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(Request.class);
 
     private URL url;
     private byte[] data;
@@ -89,7 +88,7 @@ public class Request implements Callable<Response> {
             }
             response.setStream(is);
         } catch (Exception e) {
-            log.warning(url.toString() + " exception " + e);
+            log.warn("{} exception {}", url, e);
         } finally {
             if (queue != null) {
                 queue.offer(response);

--- a/src/main/java/com/eternitywall/ots/Calendar.java
+++ b/src/main/java/com/eternitywall/ots/Calendar.java
@@ -10,7 +10,6 @@ import org.bitcoinj.core.ECKey;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * Class representing remote calendar server interface.
@@ -19,8 +18,6 @@ public class Calendar {
 
     private String url;
     private ECKey key;
-
-    private static Logger log = Utils.getLogger(Calendar.class.getName());
 
     /**
      * Create a RemoteCalendar.

--- a/src/main/java/com/eternitywall/ots/Esplora.java
+++ b/src/main/java/com/eternitywall/ots/Esplora.java
@@ -3,14 +3,15 @@ package com.eternitywall.ots;
 import com.eternitywall.http.Request;
 import com.eternitywall.http.Response;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.util.concurrent.*;
-import java.util.logging.Logger;
 
 public class Esplora {
 
-    private static final Logger log = Utils.getLogger(Esplora.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(Esplora.class);
     private static final String esploraUrl = "https://blockstream.info/api";
 
     /**
@@ -37,7 +38,7 @@ public class Esplora {
         blockHeader.setMerkleroot(merkleroot);
         blockHeader.setTime(time);
         blockHeader.setBlockHash(hash);
-        log.info(take.getFromUrl() + " " + blockHeader);
+        log.debug("{} {}", take.getFromUrl(), blockHeader);
         return blockHeader;
         //log.warning("Cannot parse merkleroot from body: " + jsonObject + ": " + e.getMessage());
     }

--- a/src/main/java/com/eternitywall/ots/OtsCli.java
+++ b/src/main/java/com/eternitywall/ots/OtsCli.java
@@ -8,6 +8,8 @@ import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Logger;
 
 /**
  * The CLI for OpenTimestamps.
@@ -31,7 +32,7 @@ import java.util.logging.Logger;
  */
 public class OtsCli {
 
-    private static Logger log = Utils.getLogger(OtsCli.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(OtsCli.class);
     private static String title = "OtsCli";
     private static String version = "1.0";
     private static List<String> calendarsUrl = new ArrayList<>();
@@ -215,7 +216,7 @@ public class OtsCli {
             String infoResult = OpenTimestamps.info(detached, verbose);
             System.out.println(infoResult);
         } catch (IOException e) {
-            log.severe("No valid file");
+            log.warn("No valid file");
         }
     }
 
@@ -227,7 +228,7 @@ public class OtsCli {
             try {
                 privateUrls = readSignature(signatureFile);
             } catch (Exception e) {
-                log.severe("No valid signature file");
+                log.warn("No valid signature file");
                 return;
             }
         }
@@ -241,12 +242,10 @@ public class OtsCli {
                 Hash hash = Hash.from(file, Hash.getOp(algorithm)._TAG());
                 mapFiles.put(argsFile, DetachedTimestampFile.from(hash));
             } catch (IOException e) {
-                e.printStackTrace();
-                log.severe("File read error");
+                log.warn("File read error", e);
                 return;
             } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
-                log.severe("Crypto error");
+                log.warn("Crypto error", e);
                 return;
             }
         }
@@ -262,8 +261,7 @@ public class OtsCli {
                 throw new IOException();
             }
         } catch (IOException e) {
-            e.printStackTrace();
-            log.severe("Stamp error");
+            log.warn("Stamp error", e);
 
             return;
         }
@@ -284,8 +282,7 @@ public class OtsCli {
                     System.out.println("The timestamp proof '" + argsOts + "' has been created!");
                 }
             } catch (Exception e) {
-                e.printStackTrace();
-                log.severe("File '" + argsOts + "' writing error");
+                log.warn("File '{}' writing error: {}", argsOts, e);
             }
         }
     }
@@ -297,7 +294,7 @@ public class OtsCli {
             try {
                 privateUrls = readSignature(signatureFile);
             } catch (Exception e) {
-                log.severe("No valid signature file");
+                log.warn("No valid signature file");
             }
         }
 
@@ -315,7 +312,7 @@ public class OtsCli {
             Files.write(path, stampResult.serialize());
             System.out.println("The timestamp proof '" + argsOts + "' has been created!");
         } catch (Exception e) {
-            log.severe("Invalid shasum");
+            log.warn("Invalid shasum");
         }
     }
 
@@ -359,7 +356,7 @@ public class OtsCli {
                 return;
             }
         } catch (Exception e) {
-            log.severe("No valid file");
+            log.warn("No valid file");
         }
     }
 
@@ -391,10 +388,9 @@ public class OtsCli {
                 Files.write(pathOts, detachedOts.serialize());
             }
         } catch (IOException e) {
-            log.severe("No valid file");
+            log.warn("No valid file");
         } catch (Exception e) {
-            e.printStackTrace();
-            log.severe("Shrink error");
+            log.warn("Shrink error", e);
         }
     }
 

--- a/src/main/java/com/eternitywall/ots/StreamDeserializationContext.java
+++ b/src/main/java/com/eternitywall/ots/StreamDeserializationContext.java
@@ -1,11 +1,13 @@
 package com.eternitywall.ots;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 public class StreamDeserializationContext {
 
-    private static Logger log = Utils.getLogger(StreamDeserializationContext.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(StreamDeserializationContext.class);
 
     byte[] buffer;
     int counter = 0;
@@ -81,10 +83,10 @@ public class StreamDeserializationContext {
         int l = this.readVaruint();
 
         if ((l & 0xff) > maxLen) {
-            log.severe("varbytes max length exceeded;");
+            log.warn("varbytes max length exceeded;");
             return null;
         } else if ((l & 0xff) < minLen) {
-            log.severe("varbytes min length not met;");
+            log.warn("varbytes min length not met;");
             return null;
         }
 

--- a/src/main/java/com/eternitywall/ots/StreamSerializationContext.java
+++ b/src/main/java/com/eternitywall/ots/StreamSerializationContext.java
@@ -3,11 +3,8 @@ package com.eternitywall.ots;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class StreamSerializationContext {
-
-    private static Logger log = Utils.getLogger(StreamSerializationContext.class.getName());
 
     List<Byte> buffer = new ArrayList<>();
 

--- a/src/main/java/com/eternitywall/ots/Timestamp.java
+++ b/src/main/java/com/eternitywall/ots/Timestamp.java
@@ -7,10 +7,11 @@ import com.eternitywall.ots.op.OpBinary;
 import com.eternitywall.ots.op.OpSHA256;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
 
 /**
  * Proof that one or more attestations commit to a message.
@@ -19,8 +20,6 @@ import java.util.logging.Logger;
  * attestations that attest to the time that messages in the tree existed prior.
  */
 public class Timestamp {
-
-    private static Logger log = Utils.getLogger(Timestamp.class.getName());
 
     public byte[] msg;
     public List<TimeAttestation> attestations;

--- a/src/main/java/com/eternitywall/ots/Utils.java
+++ b/src/main/java/com/eternitywall/ots/Utils.java
@@ -197,22 +197,4 @@ public class Utils {
     public static String toUpperFirstLetter(String string) {
         return string.substring(0, 1).toUpperCase() + string.substring(1).toLowerCase();
     }
-
-    // TODO: This is not the way to do logging. Fix later, possibly with slf4j annotation. Need to read up on the subject.
-    public static Logger getLogger(String name) {
-        Logger log = Logger.getLogger(name);
-        ConsoleHandler handler = new ConsoleHandler();
-
-        handler.setFormatter(new SimpleFormatter() {
-            @Override
-            public synchronized String format(LogRecord lr) {
-                return lr.getMessage() + "\r\n";
-            }
-        });
-
-        log.setUseParentHandlers(false);
-        log.addHandler(handler);
-
-        return log;
-    }
 }

--- a/src/main/java/com/eternitywall/ots/attestation/BitcoinBlockHeaderAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/BitcoinBlockHeaderAttestation.java
@@ -7,7 +7,6 @@ import com.eternitywall.ots.Utils;
 import com.eternitywall.ots.exceptions.VerificationException;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Bitcoin Block Header Attestation.
@@ -37,7 +36,6 @@ import java.util.logging.Logger;
 public class BitcoinBlockHeaderAttestation extends TimeAttestation {
 
     public static byte[] _TAG = {(byte) 0x05, (byte) 0x88, (byte) 0x96, (byte) 0x0d, (byte) 0x73, (byte) 0xd7, (byte) 0x19, (byte) 0x01};
-    private static Logger log = Utils.getLogger(BitcoinBlockHeaderAttestation.class.getName());
     public static String chain = "bitcoin";
 
     @Override

--- a/src/main/java/com/eternitywall/ots/attestation/EthereumBlockHeaderAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/EthereumBlockHeaderAttestation.java
@@ -2,10 +2,8 @@ package com.eternitywall.ots.attestation;
 
 import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.StreamSerializationContext;
-import com.eternitywall.ots.Utils;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Ethereum Block Header Attestation.
@@ -15,7 +13,6 @@ import java.util.logging.Logger;
 public class EthereumBlockHeaderAttestation extends TimeAttestation {
 
     public static byte[] _TAG = {(byte) 0x30, (byte) 0xfe, (byte) 0x80, (byte) 0x87, (byte) 0xb5, (byte) 0xc7, (byte) 0xea, (byte) 0xd7};
-    private static Logger log = Utils.getLogger(EthereumBlockHeaderAttestation.class.getName());
     public static String chain = "ethereum";
 
     @Override

--- a/src/main/java/com/eternitywall/ots/attestation/LitecoinBlockHeaderAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/LitecoinBlockHeaderAttestation.java
@@ -7,7 +7,6 @@ import com.eternitywall.ots.Utils;
 import com.eternitywall.ots.exceptions.VerificationException;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Litecoin Block Header Attestation.
@@ -17,7 +16,6 @@ import java.util.logging.Logger;
 public class LitecoinBlockHeaderAttestation extends TimeAttestation {
 
     public static byte[] _TAG = {(byte) 0x06, (byte) 0x86, (byte) 0x9a, (byte) 0x0d, (byte) 0x73, (byte) 0xd7, (byte) 0x1b, (byte) 0x45};
-    private static Logger log = Utils.getLogger(LitecoinBlockHeaderAttestation.class.getName());
     public static String chain = "litecoin";
 
     @Override

--- a/src/main/java/com/eternitywall/ots/attestation/PendingAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/PendingAttestation.java
@@ -3,10 +3,11 @@ package com.eternitywall.ots.attestation;
 import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.StreamSerializationContext;
 import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Pending attestations.
@@ -30,7 +31,7 @@ import java.util.logging.Logger;
  */
 public class PendingAttestation extends TimeAttestation {
 
-    private static Logger log = Utils.getLogger(PendingAttestation.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(PendingAttestation.class);
 
     public static byte[] _TAG = {(byte) 0x83, (byte) 0xdf, (byte) 0xe3, (byte) 0x0d, (byte) 0x2e, (byte) 0xf9, (byte) 0x0c, (byte) 0x8e};
 
@@ -65,7 +66,7 @@ public class PendingAttestation extends TimeAttestation {
             Character c = String.format("%c", uri[i]).charAt(0);
 
             if (PendingAttestation._ALLOWED_URI_CHARS.indexOf(c) < 0) {
-                log.severe("URI contains invalid character ");
+                log.warn("URI contains invalid character: {}", c);
 
                 return false;
             }
@@ -78,7 +79,7 @@ public class PendingAttestation extends TimeAttestation {
         byte[] utf8Uri = ctxPayload.readVarbytes(PendingAttestation._MAX_URI_LENGTH);
 
         if (PendingAttestation.checkUri(utf8Uri) == false) {
-            log.severe("Invalid URI: ");
+            log.warn("Invalid URI: ");
 
             return null;
         }

--- a/src/main/java/com/eternitywall/ots/attestation/TimeAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/TimeAttestation.java
@@ -3,16 +3,15 @@ package com.eternitywall.ots.attestation;
 import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.StreamSerializationContext;
 import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Class representing {@link com.eternitywall.ots.Timestamp} signature verification
  */
 public abstract class TimeAttestation implements Comparable<TimeAttestation> {
-
-    private static Logger log = Utils.getLogger(TimeAttestation.class.getName());
 
     public static int _TAG_SIZE = 8;
 

--- a/src/main/java/com/eternitywall/ots/attestation/UnknownAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/UnknownAttestation.java
@@ -14,8 +14,6 @@ import java.util.logging.Logger;
  */
 public class UnknownAttestation extends TimeAttestation {
 
-    private static Logger log = Utils.getLogger(UnknownAttestation.class.getName());
-
     byte[] payload;
 
     public static byte[] _TAG = new byte[]{};

--- a/src/main/java/com/eternitywall/ots/op/Op.java
+++ b/src/main/java/com/eternitywall/ots/op/Op.java
@@ -2,16 +2,15 @@ package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.StreamSerializationContext;
-import com.eternitywall.ots.Utils;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Operations are the edges in the timestamp tree, with each operation taking a message and zero or more arguments to produce a result.
  */
 public abstract class Op implements Comparable<Op> {
 
-    private static Logger log = Utils.getLogger(Op.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(Op.class);
 
     /**
      * Maximum length of an com.eternitywall.ots.op.Op result
@@ -88,7 +87,7 @@ public abstract class Op implements Comparable<Op> {
         } else if (tag == OpKECCAK256._TAG) {
             return OpKECCAK256.deserializeFromTag(ctx, tag);
         } else {
-            log.severe("Unknown operation tag: " + tag + " 0x" + String.format("%02x", tag));
+            log.warn("Unknown operation tag: {} 0x{}", tag, String.format("%02x", tag));
             return null;     // TODO: Is this OK? Won't it blow up later? Better to throw?
         }
     }
@@ -100,7 +99,7 @@ public abstract class Op implements Comparable<Op> {
      */
     public void serialize(StreamSerializationContext ctx) {
         if (this._TAG() == 0x00) {
-            log.severe("No valid serialized Op");
+            log.warn("No valid serialized Op");
             // TODO: Is it OK to just log and carry on? Won't it blow up later? Better to throw?
         }
 
@@ -117,14 +116,14 @@ public abstract class Op implements Comparable<Op> {
      */
     public byte[] call(byte[] msg) {
         if (msg.length > _MAX_MSG_LENGTH) {
-            log.severe("Error : Message too long;");
+            log.warn("Error : Message too long;");
             return new byte[]{};     // TODO: Is this OK? Won't it blow up later? Better to throw?
         }
 
         byte[] r = this.call(msg);
 
         if (r.length > _MAX_RESULT_LENGTH) {
-            log.severe("Error : Result too long;");
+            log.warn("Error : Result too long;");
             // TODO: Is it OK to just log and carry on? Won't it blow up later? Better to throw?
         }
 

--- a/src/main/java/com/eternitywall/ots/op/OpAppend.java
+++ b/src/main/java/com/eternitywall/ots/op/OpAppend.java
@@ -13,8 +13,6 @@ import java.util.logging.Logger;
  */
 public class OpAppend extends OpBinary {
 
-    private static Logger log = Utils.getLogger(OpAppend.class.getName());
-
     byte[] arg;
 
     public static byte _TAG = (byte) 0xf0;

--- a/src/main/java/com/eternitywall/ots/op/OpBinary.java
+++ b/src/main/java/com/eternitywall/ots/op/OpBinary.java
@@ -3,9 +3,10 @@ package com.eternitywall.ots.op;
 import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.StreamSerializationContext;
 import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Operations that act on a message and a single argument.
@@ -14,7 +15,7 @@ import java.util.logging.Logger;
  */
 public abstract class OpBinary extends Op implements Comparable<Op> {
 
-    private static Logger log = Utils.getLogger(OpBinary.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(OpBinary.class);
 
     public byte[] arg;
 
@@ -41,7 +42,7 @@ public abstract class OpBinary extends Op implements Comparable<Op> {
         } else if (tag == OpPrepend._TAG) {
             return new OpPrepend(arg);
         } else {
-            log.severe("Unknown operation tag: " + tag + " 0x" + String.format("%02x", tag));
+            log.warn("Unknown operation tag: {} 0x{}", tag, String.format("%02x", tag));
             return null;     // TODO: Is this OK? Won't it blow up later? Better to throw?
         }
     }

--- a/src/main/java/com/eternitywall/ots/op/OpCrypto.java
+++ b/src/main/java/com/eternitywall/ots/op/OpCrypto.java
@@ -1,7 +1,8 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -9,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.logging.Logger;
 
 /**
  * Cryptographic transformations.
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  */
 public class OpCrypto extends OpUnary {
 
-    private static Logger log = Utils.getLogger(OpCrypto.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(OpCrypto.class);
 
     public String _TAG_NAME = "";
 
@@ -50,8 +50,7 @@ public class OpCrypto extends OpUnary {
 
             return hash;
         } catch (NoSuchAlgorithmException e) {
-            log.severe("NoSuchAlgorithmException");
-            e.printStackTrace();
+            log.error("No such algorithm", e);
 
             return new byte[]{};     // TODO: Is this OK? Won't it blow up later? Better to throw?
         }

--- a/src/main/java/com/eternitywall/ots/op/OpKECCAK256.java
+++ b/src/main/java/com/eternitywall/ots/op/OpKECCAK256.java
@@ -1,10 +1,7 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
 import com.eternitywall.ots.crypto.KeccakDigest;
-
-import java.util.logging.Logger;
 
 /**
  * Cryptographic Keccak256 operation.
@@ -15,7 +12,6 @@ import java.util.logging.Logger;
  */
 public class OpKECCAK256 extends OpCrypto {
 
-    private static Logger log = Utils.getLogger(OpKECCAK256.class.getName());
     private KeccakDigest digest = new KeccakDigest(256);
 
     public static byte _TAG = (byte) 103;

--- a/src/main/java/com/eternitywall/ots/op/OpPrepend.java
+++ b/src/main/java/com/eternitywall/ots/op/OpPrepend.java
@@ -4,7 +4,6 @@ import com.eternitywall.ots.StreamDeserializationContext;
 import com.eternitywall.ots.Utils;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 /**
  * Prepend a prefix to a message.
@@ -12,8 +11,6 @@ import java.util.logging.Logger;
  * @see OpBinary
  */
 public class OpPrepend extends OpBinary {
-
-    private static Logger log = Utils.getLogger(OpPrepend.class.getName());
 
     byte[] arg;
 

--- a/src/main/java/com/eternitywall/ots/op/OpRIPEMD160.java
+++ b/src/main/java/com/eternitywall/ots/op/OpRIPEMD160.java
@@ -1,10 +1,7 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
 import com.eternitywall.ots.crypto.RIPEMD160Digest;
-
-import java.util.logging.Logger;
 
 /**
  * Cryptographic RIPEMD160 operation.
@@ -14,8 +11,6 @@ import java.util.logging.Logger;
  * @see OpCrypto
  */
 public class OpRIPEMD160 extends OpCrypto {
-
-    private static Logger log = Utils.getLogger(OpRIPEMD160.class.getName());
 
     public static byte _TAG = 0x03;
 

--- a/src/main/java/com/eternitywall/ots/op/OpSHA1.java
+++ b/src/main/java/com/eternitywall/ots/op/OpSHA1.java
@@ -1,9 +1,6 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
-
-import java.util.logging.Logger;
 
 /**
  * Cryptographic SHA1 operation.
@@ -19,8 +16,6 @@ import java.util.logging.Logger;
  * @see OpCrypto
  */
 public class OpSHA1 extends OpCrypto {
-
-    private static Logger log = Utils.getLogger(OpSHA1.class.getName());
 
     public static byte _TAG = 0x02;
 

--- a/src/main/java/com/eternitywall/ots/op/OpSHA256.java
+++ b/src/main/java/com/eternitywall/ots/op/OpSHA256.java
@@ -1,9 +1,6 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
-
-import java.util.logging.Logger;
 
 /**
  * Cryptographic SHA256 operation.
@@ -13,8 +10,6 @@ import java.util.logging.Logger;
  * @see OpCrypto
  */
 public class OpSHA256 extends OpCrypto {
-
-    private static Logger log = Utils.getLogger(OpSHA256.class.getName());
 
     public static byte _TAG = 0x08;
 

--- a/src/main/java/com/eternitywall/ots/op/OpUnary.java
+++ b/src/main/java/com/eternitywall/ots/op/OpUnary.java
@@ -1,9 +1,9 @@
 package com.eternitywall.ots.op;
 
 import com.eternitywall.ots.StreamDeserializationContext;
-import com.eternitywall.ots.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.logging.Logger;
 
 /**
  * Operations that act on a single message.
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
  */
 public abstract class OpUnary extends Op {
 
-    private static Logger log = Utils.getLogger(OpUnary.class.getName());
+    private static Logger log = LoggerFactory.getLogger(OpUnary.class);
 
     @Override
     public String _TAG_NAME() {
@@ -33,7 +33,7 @@ public abstract class OpUnary extends Op {
         } else if (tag == OpKECCAK256._TAG) {
             return new OpKECCAK256();
         } else {
-            log.severe("Unknown operation tag: " + tag);
+            log.warn("Unknown operation tag: {}", tag);
 
             return null;     // TODO: Is this OK? Won't it blow up later? Better to throw?
         }

--- a/src/test/java/com/eternitywall/TestBitcoin.java
+++ b/src/test/java/com/eternitywall/TestBitcoin.java
@@ -2,19 +2,19 @@ package com.eternitywall;
 
 import com.eternitywall.ots.BitcoinNode;
 import com.eternitywall.ots.BlockHeader;
-import com.eternitywall.ots.Utils;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Properties;
-import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class TestBitcoin {
 
-    private static Logger log = Utils.getLogger(TestBitcoin.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(TestBitcoin.class);
 
     @Test
     public void testBitcoin() {

--- a/src/test/java/com/eternitywall/TestCalendar.java
+++ b/src/test/java/com/eternitywall/TestCalendar.java
@@ -9,6 +9,8 @@ import org.bitcoinj.core.DumpedPrivateKey;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.math.BigInteger;
@@ -23,12 +25,11 @@ import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.logging.Logger;
 
 import static org.junit.Assert.*;
 
 public class TestCalendar {
-    private static Logger log = Utils.getLogger(TestCalendar.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(TestCalendar.class);
 
     @Test
     public void testSingle() throws Exception {
@@ -220,7 +221,7 @@ public class TestCalendar {
         }
 
         if (count < m) {
-            log.severe("Failed to create timestamp: requested " + String.valueOf(m) + " attestation" + ((m > 1) ? "s" : "") + " but received only " + String.valueOf(count));
+            log.warn("Failed to create timestamp: requested {} attestation{} but received only {}", m, (m > 1) ? "s" : "", count);
         }
 
         assertFalse(count < m);
@@ -269,7 +270,7 @@ public class TestCalendar {
         }
 
         if (count < m) {
-            log.severe("Failed to create timestamp: requested " + String.valueOf(m) + " attestation" + ((m > 1) ? "s" : "") + " but received only " + String.valueOf(count));
+            log.warn("Failed to create timestamp: requested {} attestations but received only {}", m, count);
         }
 
         assertFalse(count < m);


### PR DESCRIPTION
This is based on the conversation over on opentimestamps/java-opentimestamps#48. I have migrated the project from using `java.util.logging` to SLF4J. This should make it easier for those depending on this library to control the logging that is coming out of the library.

There are some changes to how the CLI application needs to be built. Now when creating the OtsCli.jar it should be built with `mvn install -P cli` which will activate the CLI profile. This adds Logback Classic and a basic stdout log appender configuration to the CLI jar. This will allow log messages to be emitted on the command line.

All references to `java.util.logging` have now been removed with SLF4J as the preferred approach. Also the tests have a dependency on Logback Classic to ensure that the correct log message is output on one of the tests.

# Remaining tasks

- [ ] Test this with an existing application to make sure that the logging can be configured as required.