### PR TITLE
Removed static scope from the _TAG member variable in UnknownAttestation

### DIFF
--- a/src/main/java/com/eternitywall/ots/attestation/UnknownAttestation.java
+++ b/src/main/java/com/eternitywall/ots/attestation/UnknownAttestation.java
@@ -19,7 +19,7 @@ public class UnknownAttestation extends TimeAttestation {
 
     byte[] payload;
 
-    public static byte[] _TAG = new byte[]{};
+    public byte[] _TAG = new byte[]{};
 
     @Override
     public byte[] _TAG() {


### PR DESCRIPTION
Removed static scope from the _TAG member variable in UnknownAttestation.

```
 UnknownAttestation(byte[] tag, byte[] payload) {
        super();
        this._TAG = tag;
        this.payload = payload;
    }
```
In constructor, for each instance it is getting overrided.

```
        if (!Arrays.equals(this._TAG(), ((UnknownAttestation) obj)._TAG())) {
            return false;
        }
```
Since _TAG is declared static always this if statement will be false.